### PR TITLE
Fix pure prompt installation

### DIFF
--- a/.antigenrc
+++ b/.antigenrc
@@ -20,8 +20,7 @@ antigen bundle zsh-users/zsh-autosuggestions
 # use pure,
 # https://github.com/sindresorhus/pure#antigen
 antigen bundle mafredri/zsh-async
-antigen bundle sindresorhus/pure
+antigen bundle sindresorhus/pure --branch=main
 
 # tell antigen that you're done.
 antigen apply
- 


### PR DESCRIPTION
They renamed the default branch to `main` months ago and therefore broke installation: https://github.com/sindresorhus/pure/pull/581

This PR specifies the branch to `main` to fix the problem 🙄 